### PR TITLE
se realiza modo mini para ocultar botones y dejar limpia la interfaz …

### DIFF
--- a/src/app/page.module.css
+++ b/src/app/page.module.css
@@ -31,6 +31,24 @@
   transition: background-color 0.2s ease, transform 0.1s ease;
   min-width: 100px;
 }
+
+.mainContainer.miniModeActive .presetButtons,
+.mainContainer.miniModeActive .customInputContainer,
+.mainContainer.miniModeActive .projectBranding, 
+.mainContainer.miniModeActive .instructionText {
+  display: none;
+}
+
+.mainContainer.miniModeActive .timerDisplay {
+  font-size: 3.5rem;
+  margin-bottom: 15px;
+}
+
+.mainContainer.miniModeActive {
+  padding-top: 20px;
+  justify-content: center;
+}
+
 .button:hover { background-color: #444; border-color: #777; }
 .button:active { background-color: #222; transform: translateY(1px); }
 .button:disabled { background-color: #252525; color: #666; cursor: not-allowed; border-color: #404040; }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -17,6 +17,7 @@ export default function HomePage() {
   const [initialTimeSet, setInitialTimeSet] = useState<number>(0);
   const [customHoursInput, setCustomHoursInput] = useState<string>('');
   const [customMinutesInput, setCustomMinutesInput] = useState<string>('');
+  const [isMiniMode, setIsMiniMode] = useState<boolean>(false);
 
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
 
@@ -104,9 +105,11 @@ export default function HomePage() {
   };
 
   return (
-    <main className={styles.mainContainer}>
-      <ProjectBranding />
-      <TimerDisplay timeParts={timeParts} />
+    <main className={`${styles.mainContainer} ${isMiniMode ? styles.miniModeActive : ''}`}>
+  {!isMiniMode && <ProjectBranding />}
+  <TimerDisplay timeParts={timeParts} />
+  {!isMiniMode && (
+    <>
       <PresetButtons
         onSetTime={startTimer}
         disabled={isActive && totalSeconds > 0}
@@ -120,7 +123,9 @@ export default function HomePage() {
         inputsDisabled={isActive && totalSeconds > 0}
         disabled={ (isActive && totalSeconds > 0) || (!customHoursInput && !customMinutesInput)}
       />
-      <TimerControls
+    </>
+  )}
+  <TimerControls
         isActive={isActive}
         initialTimeSet={initialTimeSet}
         totalSeconds={totalSeconds}
@@ -128,11 +133,18 @@ export default function HomePage() {
         onReset={resetTimer}
         onStop={stopTimer}
       />
-      {totalSeconds === 0 && !isActive && initialTimeSet === 0 && (
+          {totalSeconds === 0 && !isActive && initialTimeSet === 0 && (
         <p className={styles.instructionText}>
           Selecciona un tiempo predefinido o ingresa minutos personalizados para comenzar.
         </p>
       )}
-    </main>
+<button
+  onClick={() => setIsMiniMode(!isMiniMode)}
+  className={styles.button}
+>
+  {isMiniMode ? 'Vista Completa' : 'Modo Mini'}
+</button>
+</main>
   );
 }
+


### PR DESCRIPTION
## PR: Implementar Modo Mini (Widget View)

**Descripción:**

Este PR introduce la funcionalidad de "Modo Mini" a Prod-UIBO. Esta vista permite al usuario enfocarse únicamente en el temporizador, ocultando los controles adicionales y la marca del proyecto, creando una experiencia similar a un widget dentro de la misma página web.

Se ha añadido un botón para alternar entre la vista completa y el Modo Mini.

**Cambios Realizados:**

1.  **`src/app/page.tsx`**:
    * Se añadió un nuevo estado `isMiniMode` (booleano) para controlar la vista actual.
    * Se agregó un botón "Modo Mini" / "Vista Completa" para alternar este estado.
    * Se implementó el renderizado condicional para ocultar `ProjectBranding`, `PresetButtons`, `CustomTimeInput` y el texto de instrucción cuando `isMiniMode` es `true`.
2.  **`src/app/page.module.css`**:
    * Se añadieron nuevas clases CSS (`.miniModeActive`, `.miniModeButtonContainer`) y estilos para gestionar la apariencia del Modo Mini.
    * En Modo Mini, el `TimerDisplay` se reduce en tamaño y se ajusta el padding del contenedor principal.

![Captura de pantalla 2025-05-20 a la(s) 14 08 01](https://github.com/user-attachments/assets/c661e20e-a0af-466a-a00e-74a80f6627d9)
